### PR TITLE
ensure that ledger only renders on desktop environments

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
   ],
   testRegex: "(/src/.*(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   testEnvironment: "jsdom",
+  "testURL": "https://testing.io",
   moduleNameMapper: {
     'eosjs': '<rootDir>/src/__mocks__/eosjs.ts'
   },

--- a/src/Ledger.test.ts
+++ b/src/Ledger.test.ts
@@ -5,6 +5,20 @@ import { CONSTANTS } from './constants'
 import { Name } from './interfaces'
 import { ledgerLogo } from './ledgerLogo'
 
+declare var window: any
+
+// Make userAgent mutable for testing
+Object.defineProperty(window.navigator, 'userAgent', ((val) => {
+  return {
+    get: () => val,
+    set: (v) => {
+      val = v
+    }
+  }
+})(window.navigator.userAgent))
+
+
+
 describe('Ledger', () => {
   let app
   const exampleNet = {
@@ -58,5 +72,32 @@ describe('Ledger', () => {
     await expect(app.login())
       .rejects
       .toThrow('Account validation failed for account undefined.')
+  })
+
+  describe('should render', () => {
+    let desktopBrowser: string
+    let mobileBrowser: string
+    let embeddedBrowser: string
+
+    beforeAll(() => {
+      desktopBrowser = 'Chrome'
+      mobileBrowser = 'iPhone'
+      embeddedBrowser = 'EosLynx Android'
+    })
+
+    it('only on desktop', () => {
+      window.navigator.userAgent = desktopBrowser
+      expect(app.shouldRender()).toBe(true)
+    })
+
+    it('not on mobile', () => {
+      window.navigator.userAgent = mobileBrowser
+      expect(app.shouldRender()).toBe(false)
+    })
+
+    it('not in an embedded browser', () => {
+      window.navigator.userAgent = embeddedBrowser
+      expect(app.shouldRender()).toBe(false)
+    })
   })
 })

--- a/src/Ledger.ts
+++ b/src/Ledger.ts
@@ -31,6 +31,16 @@ export class Ledger extends Authenticator {
     this.chains = chains
   }
 
+  private isMobile(): boolean {
+    const userAgent = window.navigator.userAgent
+    const isIOS = userAgent.includes('iPhone') || userAgent.includes('iPad')
+    const isMobile = userAgent.includes('Mobile')
+    const isAndroid = userAgent.includes('Android')
+    const isCustom = userAgent.toLowerCase().includes('eoslynx')
+
+    return isIOS || isMobile || isAndroid || isCustom
+  }
+
   public async init(): Promise<void> {
     console.info('Ledger initialized!')
   }
@@ -118,16 +128,6 @@ export class Ledger extends Authenticator {
 
   public reset(): void {
     return
-  }
-
-  public isMobile(): boolean {
-    const userAgent = window.navigator.userAgent
-    const isIOS = userAgent.includes('iPhone') || userAgent.includes('iPad')
-    const isMobile = userAgent.includes('Mobile')
-    const isAndroid = userAgent.includes('Android')
-    const isCustom = userAgent.toLowerCase().includes('eoslynx')
-
-    return isIOS || isMobile || isAndroid || isCustom
   }
 
   public requiresGetKeyConfirmation(accountName?: string): boolean {

--- a/src/Ledger.ts
+++ b/src/Ledger.ts
@@ -39,7 +39,7 @@ export class Ledger extends Authenticator {
    * Ledger will only work with ssl secured websites
    */
   public shouldRender(): boolean {
-    if (window.location.protocol !== 'https:') {
+    if (window.location.protocol !== 'https:' || this.isMobile()) {
       return false
     }
 
@@ -118,6 +118,16 @@ export class Ledger extends Authenticator {
 
   public reset(): void {
     return
+  }
+
+  public isMobile(): boolean {
+    const userAgent = window.navigator.userAgent
+    const isIOS = userAgent.includes('iPhone') || userAgent.includes('iPad')
+    const isMobile = userAgent.includes('Mobile')
+    const isAndroid = userAgent.includes('Android')
+    const isCustom = userAgent.toLowerCase().includes('eoslynx')
+
+    return isIOS || isMobile || isAndroid || isCustom
   }
 
   public requiresGetKeyConfirmation(accountName?: string): boolean {


### PR DESCRIPTION
## Change Description
This change addresses the issue raised in #16 


## API Changes
- [x] API Changes
* The Ledger authenticator should only render in a desktop environment.


## Documentation Additions
- [x] Documentation Additions
* add ``isMobile`` method to ``Ledger.ts`` to determine the environment that the Ledger authenticator is being used
