### PR TITLE
add getAvailableKeys, optional validation and key permission

### DIFF
--- a/src/Ledger.ts
+++ b/src/Ledger.ts
@@ -13,6 +13,8 @@ import { LedgerOptions, Name } from './interfaces'
 import { ledgerLogo } from './ledgerLogo'
 import { LedgerUser } from './LedgerUser'
 import { UALLedgerError } from './UALLedgerError'
+import { SignatureProvider } from 'eosjs-ledger-signature-provider'
+const signatureProvider = new SignatureProvider()
 
 export class Ledger extends Authenticator {
   private onBoardingLink: string = CONSTANTS.onBoardingLink
@@ -69,16 +71,25 @@ export class Ledger extends Authenticator {
    *
    * @param accountName Account Name is an optional paramter
    */
-  public async login(accountName?: string): Promise<User[]> {
+
+  public async getAvailableKeys( requestPermission: boolean = false, indexArray: number[] = [0])
+  : Promise<string[]> {
+    return await signatureProvider.getAvailableKeys(requestPermission, indexArray)
+  }
+
+  public async login(accountName?: string, requestPermission: boolean = true, validate: boolean = true)
+  : Promise<User[]> {
     for (const chain of this.chains) {
-      const user = new LedgerUser(chain, accountName, this.requiresGetKeyConfirmation(accountName))
+      const user = new LedgerUser(chain, accountName, this.requiresGetKeyConfirmation(accountName) && requestPermission)
       await user.init()
-      const isValid = await user.isAccountValid()
-      if (!isValid) {
-        const message = `Error logging into account "${accountName}"`
-        const type = UALErrorType.Login
-        const cause = null
-        throw new UALLedgerError(message, type, cause)
+      if (validate) {
+        const isValid = await user.isAccountValid()
+        if (!isValid) {
+          const message = `Error logging into account "${accountName}"`
+          const type = UALErrorType.Login
+          const cause = null
+          throw new UALLedgerError(message, type, cause)
+        }
       }
       this.users.push(user)
     }


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

- Expose `getAvailableKeys` of  `SignatureProvider` instance to `Authenticator` to allow UI to fetch public keys and perform account discovery before `login` is called
- Allow key verification and account validation to be optional so to allow better UX

#23 

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
